### PR TITLE
specify character encoding when reading *.py files

### DIFF
--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -143,7 +143,7 @@ def detect_flask_apps():
 
             full = os.path.join(root, filename)
 
-            with open(full, 'r') as f:
+            with open(full, 'r', encoding='utf-8') as f:
                 lines = f.readlines()
                 for line in lines:
                     app = None


### PR DESCRIPTION
`def Detect_flask_apps()` runs during `zappa init`, which may read through virtual environment library files. On Windows 10 `f.readlines()` fails when reading venv/Lib/functools.py library file because of a UnicodeDecodeError: 

`UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 301: character maps to <undefined>`

specifying the encoding fixed this.

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

